### PR TITLE
Updated Ops Manager version to 2.1

### DIFF
--- a/install-pcf/gcp/params.yml
+++ b/install-pcf/gcp/params.yml
@@ -76,7 +76,7 @@ apps_domain: CHANGEME
 ert_errands_to_disable: none
 
 # PCF Elastic Runtime minor version to track
-ert_major_minor_version: ^2\.1\.[0-9]+$ # ERT minor version to track (e.g ^2\.0\.[0-9]+$ will track 2.0.x versions)
+ert_major_minor_version: ^2\.2\.[0-9]+$ # ERT minor version to track (e.g ^2\.0\.[0-9]+$ will track 2.0.x versions)
 
 # Optional. Duration in seconds to maintain an open connection when client supports keep-alive.
 frontend_idle_timeout: 601
@@ -113,7 +113,7 @@ git_private_key:
 haproxy_backend_ca:
 
 # If enabled HAProxy will forward all requests to the router over TLS (enable|disable)
-haproxy_forward_tls: enable
+haproxy_forward_tls: disable
 
 # Whether or not the ERT VMs are internet connected.
 internet_connected: false
@@ -130,7 +130,7 @@ opsman_admin_password: CHANGEME
 opsman_domain_or_ip_address: CHANGEME #This must be your pcf_ert_domain with "opsman." as a prefix. For example, opsman.pcf.example.com
 
 # PCF Ops Manager minor version to track
-opsman_major_minor_version: ^2\.0\.[0-9]+$ # Ops Manager minor version to track (e.g ^2\.0\.[0-9]+$ will track 2.0.x versions)
+opsman_major_minor_version: ^2\.2\.[0-9]+$ # Ops Manager minor version to track (e.g ^2\.0\.[0-9]+$ will track 2.0.x versions)
 
 # Optional PEM-encoded certificates to add to BOSH director
 opsman_trusted_certs: |

--- a/install-pcf/gcp/params.yml
+++ b/install-pcf/gcp/params.yml
@@ -76,7 +76,7 @@ apps_domain: CHANGEME
 ert_errands_to_disable: none
 
 # PCF Elastic Runtime minor version to track
-ert_major_minor_version: ^2\.0\.[0-9]+$ # ERT minor version to track (e.g ^2\.0\.[0-9]+$ will track 2.0.x versions)
+ert_major_minor_version: ^2\.1\.[0-9]+$ # ERT minor version to track (e.g ^2\.0\.[0-9]+$ will track 2.0.x versions)
 
 # Optional. Duration in seconds to maintain an open connection when client supports keep-alive.
 frontend_idle_timeout: 601


### PR DESCRIPTION
Customer VM Extensions is only supported on version 2.1 and forward.

https://docs.pivotal.io/pivotalcf/2-1/customizing/custom-vm-extensions.html

Thanks for contributing to pcf-pipelines. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

* An explanation of the use cases your change solves:

* Expected result after the change:

* Current result before the change:

* Links to any other associated PRs or issues:

* [ ] I have viewed signed and have submitted the Contributor License Agreement

* [ ] I have made this pull request to the `master` branch

* [ ] I have run all the unit tests 
